### PR TITLE
Update the runtime version to from 24.08 to 25.08, and more

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "shared-modules"]
+	path = shared-modules
+	url = https://github.com/flathub/shared-modules.git

--- a/pl.suve.colorful.yaml
+++ b/pl.suve.colorful.yaml
@@ -1,19 +1,16 @@
 app-id: pl.suve.colorful
-
 runtime: org.freedesktop.Platform
-runtime-version: "24.08"
-
+runtime-version: "25.08"
 sdk: org.freedesktop.Sdk
 sdk-extensions:
   - org.freedesktop.Sdk.Extension.freepascal
-
 build-options:
   append-path: /usr/lib/sdk/freepascal/bin
   env:
     PPC_CONFIG_PATH: /usr/lib/sdk/freepascal/etc
     FPCDIR: /usr/lib/sdk/freepascal/fpcsrc
-
 command: colorful
+rename-icon: colorful
 finish-args:
   - --socket=wayland
   - --socket=fallback-x11
@@ -22,45 +19,41 @@ finish-args:
   - --device=dri
   # This should be --device=input, but flathub does not support it yet
   - --device=all
-
-rename-icon: colorful
-
 modules:
+  - shared-modules/SDL2/SDL2_image.json
   - name: optipng
-    sources:
-      - type: archive
-        url: https://netcologne.dl.sourceforge.net/project/optipng/OptiPNG/optipng-0.7.8/optipng-0.7.8.tar.gz
-        sha256: 25a3bd68481f21502ccaa0f4c13f84dcf6b20338e4c4e8c51f2cefbd8513398c
     buildsystem: autotools
     build-options:
-      config-opts: 
+      config-opts:
         - --with-system-libs
     cleanup:
       - '*'
+    sources:
+      - type: archive
+        url: https://sourceforge.net/projects/optipng/files/OptiPNG/optipng-7.9.1/optipng-7.9.1.tar.gz
+        sha256: c2579be58c2c66dae9d63154edcb3d427fef64cb00ec0aff079c9d156ec46f29
 
   - name: vorbis-tools
     buildsystem: autotools
+    cleanup:
+      - '*'
     sources:
       - type: archive
         url: https://downloads.xiph.org/releases/vorbis/vorbis-tools-1.4.2.tar.gz
         sha256: db7774ec2bf2c939b139452183669be84fda5774d6400fc57fde37f77624f0b0
       - type: patch
         path: patches-vorbis/0001-fix-build-with-gcc-14.patch
-    cleanup:
-      - '*'
 
   - name: colorful
-    sources:
-      - type: archive
-        url: https://github.com/suve/LD25/releases/download/release-2.2/colorful-2.2-source.zip
-        sha512: dce8847e6f1251f769954a092e2903ef20eda3d778de5438c3aff1ea4e8403d09170b8390df336ec53e4c776eb7f5527c4266a83dc528e2e43d9c871bbbac159
-
     buildsystem: simple
     build-commands:
       - ./configure.sh --assets=systemwide --compat=v2 --prefix=$FLATPAK_DEST
       - make executable
       - make -j assets
       - make install
-
     cleanup:
       - /share/man/
+    sources:
+      - type: archive
+        url: https://github.com/suve/LD25/releases/download/release-2.2/colorful-2.2-source.zip
+        sha512: dce8847e6f1251f769954a092e2903ef20eda3d778de5438c3aff1ea4e8403d09170b8390df336ec53e4c776eb7f5527c4266a83dc528e2e43d9c871bbbac159


### PR DESCRIPTION
- Update the runtime version to 25.08
- Update the optipng version to 7.9.1
- Comply with Flathub styling guidelines

See: https://docs.flathub.org/docs/for-app-authors/requirements#flatpak-builder-manifest-style-guide